### PR TITLE
Ensure Firebase scripts load before main.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,9 +476,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
+    <!-- Firebase SDKs -->
     <script src="https://www.gstatic.com/firebasejs/9.24.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.24.0/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.24.0/firebase-firestore-compat.js"></script>
+    <!-- Firebase initialization -->
     <script>
       const firebaseConfig = {
         apiKey: "AIzaSyCqYsuVE3oju_BT_nMDNyws-8QiglgZN-8",


### PR DESCRIPTION
## Summary
- add inline comments showing Firebase SDK and initialization blocks
- maintain Firebase initialization before main.js to avoid `firebase is not defined`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68763c720894832ea8b1dbb750c34e2c