### PR TITLE
Downgrade Firebase SDK versions to 9.22.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
         }
     </style>
     <!-- Firebase SDK -->
-    <script src="https://www.gstatic.com/firebasejs/9.24.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.24.0/firebase-auth-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.24.0/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
     <script>
       const firebaseConfig = {
         apiKey: "AIzaSyCqYsuVE3oju_BT_nMDNyws-8QiglgZN-8",


### PR DESCRIPTION
## Summary
- update Firebase compat SDK links to use version 9.22.2 in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68765fbb31ac832eb4f2b2e5b58b6230