### PR TITLE
Implement simplified admin user management

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,6 +491,8 @@
             </div>
             <div id="admin-tab-cadastro" class="admin-tab-content admin-tab-content-active">
                 <form id="client-form" class="space-y-3">
+                    <input type="text" id="client-nome" placeholder="Nome" class="w-full p-2 border rounded" required>
+                    <input type="email" id="client-email" placeholder="Email" class="w-full p-2 border rounded" required>
                     <input type="text" id="client-cnpj" placeholder="CNPJ" class="w-full p-2 border rounded" required>
                     <input type="text" id="client-razao" placeholder="Razão Social" class="w-full p-2 border rounded" required>
                     <input type="text" id="client-fantasia" placeholder="Nome Fantasia" class="w-full p-2 border rounded" required>
@@ -499,34 +501,12 @@
                         <option value="12">12 meses</option>
                         <option value="24">24 meses</option>
                     </select>
-                    <input type="email" id="client-email" placeholder="Email do usuário" class="w-full p-2 border rounded" required>
-                    <input type="password" id="client-senha" placeholder="Senha de primeiro acesso" class="w-full p-2 border rounded" required>
                     <button type="submit" class="w-full bg-indigo-600 text-white py-2 rounded">Cadastrar Usuário</button>
                 </form>
             </div>
             <div id="admin-tab-usuarios" class="admin-tab-content">
                 <div class="mt-6">
-                    <div class="flex flex-col sm:flex-row gap-2 mb-2">
-                        <input id="user-search" type="text" placeholder="Buscar por email ou CNPJ" class="flex-1 p-2 border rounded">
-                        <select id="filter-status" class="p-2 border rounded">
-                            <option value="all">Todos Status</option>
-                            <option value="ativo">Ativos</option>
-                            <option value="desativado">Desativados</option>
-                        </select>
-                        <select id="filter-tempo" class="p-2 border rounded">
-                            <option value="all">Todos Tempos</option>
-                            <option value="6">6 meses</option>
-                            <option value="12">12 meses</option>
-                            <option value="24">24 meses</option>
-                        </select>
-                        <select id="filter-situacao" class="p-2 border rounded">
-                            <option value="all">Todas Situações</option>
-                            <option value="aprovado">Liberados</option>
-                            <option value="pendente">Pendentes</option>
-                        </select>
-                        <button id="filter-btn" class="bg-slate-200 px-4 py-2 rounded">Filtrar</button>
-                    </div>
-                    <div id="clients-list" class="overflow-auto text-xs"></div>
+                    <div id="clients-list" class="text-xs"></div>
                 </div>
             </div>
 
@@ -558,11 +538,6 @@
         const cadastroErro = document.getElementById('cadastro-erro');
         const clientForm = document.getElementById('client-form');
         const clientsList = document.getElementById('clients-list');
-        const filterStatus = document.getElementById('filter-status');
-        const filterTempo = document.getElementById('filter-tempo');
-        const filterSituacao = document.getElementById('filter-situacao');
-        const userSearch = document.getElementById('user-search');
-        const filterBtn = document.getElementById('filter-btn');
         const adminTabCadastroBtn = document.getElementById('admin-tab-cadastro-btn');
         const adminTabUsuariosBtn = document.getElementById('admin-tab-usuarios-btn');
         const adminTabCadastro = document.getElementById('admin-tab-cadastro');
@@ -579,10 +554,6 @@
             el.classList.remove('hidden');
         }
 
-        filterBtn.addEventListener('click', function(e) {
-            e.preventDefault();
-            loadUsers();
-        });
 
         function switchAdminTab(tab) {
             adminTabCadastro.classList.remove('admin-tab-content-active');
@@ -653,82 +624,50 @@
 
         async function loadUsers() {
             const snap = await db.collection('usuarios').orderBy('dataCadastro', 'desc').get();
-            let users = snap.docs.map(d => ({ id: d.id, ...d.data() }));
-
-            users = users.filter(u => u.email !== adminEmail);
-
-            const status = filterStatus.value;
-            const tempo = filterTempo.value;
-            const situacao = filterSituacao.value;
-            const term = userSearch.value.trim().toLowerCase();
-
-            users = users.filter(u => (status === 'all' || u.status === status));
-            users = users.filter(u => (tempo === 'all' || String(u.tempoLiberacao) === tempo));
-            users = users.filter(u => (situacao === 'all' || (situacao === 'aprovado' ? u.aprovado : !u.aprovado)));
-            if (term) {
-                users = users.filter(u =>
-                    (u.email && u.email.toLowerCase().includes(term)) ||
-                    (u.cnpj && u.cnpj.toLowerCase().includes(term))
-                );
-            }
+            const users = snap.docs.map(d => ({ id: d.id, ...d.data() })).filter(u => u.email !== adminEmail);
 
             clientsList.innerHTML = `
-                <table class="min-w-full border">
+                <table class="min-w-full border text-xs">
                     <thead class="bg-slate-100">
                         <tr>
+                            <th class="px-2 py-1 border">Nome</th>
                             <th class="px-2 py-1 border">Email</th>
                             <th class="px-2 py-1 border">CNPJ</th>
                             <th class="px-2 py-1 border">Razão Social</th>
-                            <th class="px-2 py-1 border">Fantasia</th>
                             <th class="px-2 py-1 border">Tempo</th>
-                            <th class="px-2 py-1 border">Cadastro</th>
                             <th class="px-2 py-1 border">Status</th>
-                            <th class="px-2 py-1 border">Situação</th>
                             <th class="px-2 py-1 border">Ações</th>
                         </tr>
                     </thead>
                     <tbody>
-                        ${users.map(u => `
-                            <tr>
-                                <td class="px-2 py-1 border">${u.email || ''}</td>
-                                <td class="px-2 py-1 border">${u.cnpj || ''}</td>
-                                <td class="px-2 py-1 border">${u.razaoSocial || ''}</td>
-                                <td class="px-2 py-1 border">${u.nomeFantasia || ''}</td>
-                                <td class="px-2 py-1 border">
-                                    <select onchange="changeTempo('${u.id}', this.value)" class="p-1 border rounded">
-                                        <option value="6" ${u.tempoLiberacao==6?'selected':''}>6</option>
-                                        <option value="12" ${u.tempoLiberacao==12?'selected':''}>12</option>
-                                        <option value="24" ${u.tempoLiberacao==24?'selected':''}>24</option>
-                                    </select>
-                                </td>
-                                <td class="px-2 py-1 border">${u.dataCadastro ? u.dataCadastro.toDate().toLocaleDateString() : ''}</td>
-                                <td class="px-2 py-1 border">${u.status}</td>
-                                <td class="px-2 py-1 border">${u.aprovado ? 'Aprovado' : 'Pendente'}</td>
-                                <td class="px-2 py-1 border space-x-1 text-xs">
-                                    ${!u.aprovado ? `<button onclick="approveUser('${u.id}')" class="text-green-600">Aprovar</button>` : ''}
-                                    <button onclick="toggleStatus('${u.id}', '${u.status === 'ativo' ? 'desativado' : 'ativo'}')" class="${u.status === 'ativo' ? 'text-red-600' : 'text-green-600'}">
-                                        ${u.status === 'ativo' ? 'Desativar' : 'Ativar'}
-                                    </button>
-                                </td>
-                            </tr>
-                        `).join('')}
+                        ${users.map(u => {
+                            const status = !u.aprovado ? 'Pendente' : (u.status === 'ativo' ? 'Ativo' : 'Inativo');
+                            const toggle = status === 'Ativo' ? 'inativo' : 'ativo';
+                            return `
+                                <tr>
+                                    <td class="px-2 py-1 border">${u.nome || ''}</td>
+                                    <td class="px-2 py-1 border">${u.email || ''}</td>
+                                    <td class="px-2 py-1 border">${u.cnpj || ''}</td>
+                                    <td class="px-2 py-1 border">${u.razaoSocial || ''}</td>
+                                    <td class="px-2 py-1 border">${u.tempoLiberacao || ''}</td>
+                                    <td class="px-2 py-1 border">${status}</td>
+                                    <td class="px-2 py-1 border space-x-1">
+                                        <button onclick="toggleStatus('${u.id}', '${toggle}')" class="${status === 'Ativo' ? 'text-red-600' : 'text-green-600'} text-xs">${status === 'Ativo' ? 'Desativar' : 'Ativar'}</button>
+                                        <button onclick="editarTempo('${u.id}', ${u.tempoLiberacao || 6})" class="text-blue-600 text-xs">Editar Tempo</button>
+                                    </td>
+                                </tr>
+                            `;
+                        }).join('')}
                     </tbody>
                 </table>`;
         }
 
-        async function approveUser(id) {
-            try {
-                await db.collection('usuarios').doc(id).update({ aprovado: true, status: 'ativo' });
-                loadUsers();
-                alert('Usuário aprovado');
-            } catch (err) {
-                alert('Erro ao aprovar usuário: ' + err.message);
-            }
-        }
 
         async function toggleStatus(id, status) {
             try {
-                await db.collection('usuarios').doc(id).update({ status });
+                const update = { status };
+                if (status === 'ativo') update.aprovado = true;
+                await db.collection('usuarios').doc(id).update(update);
                 loadUsers();
                 alert('Status atualizado');
             } catch (err) {
@@ -736,9 +675,16 @@
             }
         }
 
-        async function changeTempo(id, valor) {
+        async function editarTempo(id, atual) {
+            const novo = prompt('Novo tempo de contrato (6, 12 ou 24 meses)', atual);
+            if (!novo) return;
+            const valor = parseInt(novo);
+            if (![6, 12, 24].includes(valor)) {
+                alert('Tempo inválido');
+                return;
+            }
             try {
-                await db.collection('usuarios').doc(id).update({ tempoLiberacao: parseInt(valor) });
+                await db.collection('usuarios').doc(id).update({ tempoLiberacao: valor });
                 loadUsers();
                 alert('Tempo atualizado');
             } catch (err) {
@@ -746,9 +692,8 @@
             }
         }
 
-        window.approveUser = approveUser;
         window.toggleStatus = toggleStatus;
-        window.changeTempo = changeTempo;
+        window.editarTempo = editarTempo;
 
         loginForm.addEventListener('submit', async function(e) {
             e.preventDefault();
@@ -762,21 +707,33 @@
                     show(adminScreen);
                     loadUsers();
                 } else {
-                    const doc = await db.collection('usuarios').doc(user.uid).get();
+                    const ref = db.collection('usuarios').doc(user.uid);
+                    const doc = await ref.get();
+                    let data;
                     if (doc.exists) {
-                        const data = doc.data();
-                        if (!data.aprovado) {
-                            alert('Aguardando aprovação do administrador');
-                            await auth.signOut();
-                            return;
-                        }
-                        if (data.status === 'desativado') {
-                            alert('Usuário desativado');
-                            await auth.signOut();
-                            return;
-                        }
-                        localStorage.setItem('usuario', JSON.stringify(data));
+                        data = doc.data();
+                    } else {
+                        data = {
+                            nome: user.displayName || '',
+                            email: user.email,
+                            status: 'ativo',
+                            aprovado: true,
+                            tempoLiberacao: 6,
+                            dataCadastro: firebase.firestore.FieldValue.serverTimestamp()
+                        };
+                        await ref.set(data);
                     }
+                    if (!data.aprovado) {
+                        alert('Aguardando aprovação do administrador');
+                        await auth.signOut();
+                        return;
+                    }
+                    if (data.status === 'desativado') {
+                        alert('Usuário desativado');
+                        await auth.signOut();
+                        return;
+                    }
+                    localStorage.setItem('usuario', JSON.stringify(data));
                     show(mainApp);
                 }
             } catch (err) {
@@ -806,16 +763,19 @@
 
         clientForm.addEventListener('submit', async function(e) {
             e.preventDefault();
+            const nome = document.getElementById('client-nome').value;
+            const email = document.getElementById('client-email').value;
             const cnpj = document.getElementById('client-cnpj').value;
             const razao = document.getElementById('client-razao').value;
             const fantasia = document.getElementById('client-fantasia').value;
             const tempo = document.getElementById('client-tempo').value;
-            const email = document.getElementById('client-email').value;
-            const senha = document.getElementById('client-senha').value;
             try {
                 const secApp = firebase.initializeApp(firebase.app().options, 'sec');
-                const cred = await secApp.auth().createUserWithEmailAndPassword(email, senha);
+                const tempPass = Math.random().toString(36).slice(-10);
+                const cred = await secApp.auth().createUserWithEmailAndPassword(email, tempPass);
+                await secApp.auth().sendPasswordResetEmail(email);
                 await db.collection('usuarios').doc(cred.user.uid).set({
+                    nome,
                     email,
                     cnpj,
                     razaoSocial: razao,


### PR DESCRIPTION
## Summary
- simplify admin user list UI and remove filters
- add user name field and remove password requirement
- send password reset email on admin-created users
- allow editing contract time via prompt
- automatically create Firestore record on user login if missing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6876a1ca53f4832e80c357e8eb6fedd2