### PR TITLE
Ajustes visuais em login e PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,11 +34,7 @@
             color: #333;
         }
         .pdf-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            border-bottom: 2px solid #ccc;
-            padding-bottom: 1rem;
+            text-align: center;
             margin-bottom: 1rem;
         }
         .pdf-table {
@@ -102,10 +98,8 @@
 
     <!-- =========== AUTENTICAÇÃO =========== -->
     <div id="auth-screen" class="relative min-h-screen flex items-end justify-center p-4">
-        <div class="absolute bottom-8 left-1/2 -translate-x-1/2 w-full max-w-md bg-white/80 p-6 rounded-xl shadow-lg text-center">
-            <img src="https://i.imgur.com/5faoeha.jpeg" alt="Logo" class="mx-auto mb-4">
+        <div class="absolute bottom-4 left-1/2 -translate-x-1/2 w-[90%] max-w-[350px] bg-white/80 p-6 text-center">
             <div id="login-form-div" class="space-y-4">
-                <h2 class="text-xl font-bold mb-4">Acessar Conta</h2>
                 <form id="login-form" class="space-y-4">
                     <input type="email" id="login-email" placeholder="Email" class="w-full p-3 border border-slate-300 rounded-lg" required>
                     <input type="password" id="login-password" placeholder="Senha" class="w-full p-3 border border-slate-300 rounded-lg" required>
@@ -496,7 +490,7 @@
     <!-- Container oculto para gerar o conteúdo detalhado do PDF -->
     <div id="pdf-detailed-content" class="hidden" style="position: absolute; left: -9999px; width: 800px; background: white; padding: 20px;">
         <div class="pdf-header">
-            <img src="https://i.imgur.com/5faoeha.jpeg" alt="Logo" style="max-height:60px;">
+            <img src="https://i.imgur.com/5faoeha.jpeg" alt="Logo" style="max-width:120px;margin:0 auto;display:block;">
         </div>
     </div>
 


### PR DESCRIPTION
## Resumo
- remove logo e título da tela de login
- ajusta posicionamento e tamanho da caixa de login
- centraliza logo no PDF e define largura máxima

## Testes
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6876e8d3e290832e874db8cc21e36e82